### PR TITLE
EARTH-648: Video player title fades

### DIFF
--- a/modules/stanford_paragraph_video/stanford_paragraph_video.module
+++ b/modules/stanford_paragraph_video/stanford_paragraph_video.module
@@ -9,6 +9,7 @@
  * Implements hook_preprocess_field().
  */
 function stanford_paragraph_video_preprocess_field(&$variables) {
+
   if ($variables['field_name'] != 'field_p_video_url') {
     return;
   }

--- a/modules/stanford_paragraph_video/stanford_paragraph_video.module
+++ b/modules/stanford_paragraph_video/stanford_paragraph_video.module
@@ -16,6 +16,7 @@ function stanford_paragraph_video_preprocess_field(&$variables) {
   // Some always set variables.
   $variables['items'][0]['content']['children']['#query']['showinfo'] = FALSE;
   $variables['items'][0]['content']['children']['#query']['rel'] = FALSE;
+  $variables['items'][0]['content']['children']['#query']['enablejsapi'] = TRUE;
 
   /** @var \Drupal\Core\Field\FieldItemList $autoplay_field */
   $autoplay_field = $variables['element']['#object']->get('field_p_video_autoplay');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Video player title handling for mobile and desktop

# Needed By (Date)
- End of next sprint

# Urgency
- Not sure

# Steps to Test

See: https://github.com/stanford-earth/matson/pull/151

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)