### PR TITLE
EARTH-990: Allow for muted option on video

### DIFF
--- a/modules/stanford_paragraph_video/config/install/core.entity_form_display.paragraph.stanford_video.default.yml
+++ b/modules/stanford_paragraph_video/config/install/core.entity_form_display.paragraph.stanford_video.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.stanford_video.field_p_video_autoplay
     - field.field.paragraph.stanford_video.field_p_video_loop
+    - field.field.paragraph.stanford_video.field_p_video_muted
     - field.field.paragraph.stanford_video.field_p_video_subheading
     - field.field.paragraph.stanford_video.field_p_video_title
     - field.field.paragraph.stanford_video.field_p_video_url
@@ -19,6 +20,7 @@ third_party_settings:
         - field_p_video_width
         - field_p_video_autoplay
         - field_p_video_loop
+        - field_p_video_muted
       parent_name: ''
       weight: 3
       format_type: tab
@@ -43,6 +45,13 @@ content:
     region: content
   field_p_video_loop:
     weight: 4
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_p_video_muted:
+    weight: 5
     settings:
       display_label: true
     third_party_settings: {  }

--- a/modules/stanford_paragraph_video/config/install/core.entity_view_display.paragraph.stanford_video.default.yml
+++ b/modules/stanford_paragraph_video/config/install/core.entity_view_display.paragraph.stanford_video.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.stanford_video.field_p_video_autoplay
     - field.field.paragraph.stanford_video.field_p_video_loop
+    - field.field.paragraph.stanford_video.field_p_video_muted
     - field.field.paragraph.stanford_video.field_p_video_subheading
     - field.field.paragraph.stanford_video.field_p_video_title
     - field.field.paragraph.stanford_video.field_p_video_url
@@ -82,6 +83,7 @@ content:
       width: 854
       height: 480
       autoplay: false
+      muted: false
     third_party_settings:
       field_formatter_class:
         class: ''
@@ -91,3 +93,4 @@ hidden:
   field_p_video_autoplay: true
   field_p_video_loop: true
   field_p_video_width: true
+  field_p_video_muted: true

--- a/modules/stanford_paragraph_video/config/install/field.field.paragraph.stanford_video.field_p_video_muted.yml
+++ b/modules/stanford_paragraph_video/config/install/field.field.paragraph.stanford_video.field_p_video_muted.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_p_video_muted
+    - paragraphs.paragraphs_type.stanford_video
+id: paragraph.stanford_video.field_p_video_muted
+field_name: field_p_video_muted
+entity_type: paragraph
+bundle: stanford_video
+label: 'Mute Video'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/stanford_paragraph_video/config/install/field.storage.paragraph.field_p_video_muted.yml
+++ b/modules/stanford_paragraph_video/config/install/field.storage.paragraph.field_p_video_muted.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_p_video_muted
+field_name: field_p_video_muted
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/stanford_paragraph_video/stanford_paragraph_video.module
+++ b/modules/stanford_paragraph_video/stanford_paragraph_video.module
@@ -21,7 +21,6 @@ function stanford_paragraph_video_preprocess_field(&$variables) {
 
   /** @var \Drupal\Core\Field\FieldItemList $autoplay_field */
   $autoplay_field = $variables['element']['#object']->get('field_p_video_autoplay');
-
   if ($autoplay_field && $autoplay_field->getValue()) {
     $autoplay = $autoplay_field->getValue();
 
@@ -31,6 +30,7 @@ function stanford_paragraph_video_preprocess_field(&$variables) {
     }
   }
 
+  // Pass through the value of the loop field.
   $loop_field = $variables['element']['#object']->get('field_p_video_loop');
   if ($loop_field && $loop_field->getValue()) {
     $loop = $loop_field->getValue();
@@ -42,6 +42,21 @@ function stanford_paragraph_video_preprocess_field(&$variables) {
       $video_hash = array_pop($explody);
       $variables['items'][0]['content']['children']['#query']['playlist'] = $video_hash;
     }
+  }
+
+  try {
+    $muted_field = $variables['element']['#object']->get('field_p_video_muted');
+    if ($muted_field && $muted_field->getValue()) {
+      $muted_field = $muted_field->getValue();
+
+      // If the paragraph is checked to autoplay, set the query parameter.
+      if ($muted_field[0]['value']) {
+        $variables['items'][0]['content']['children']['#query']['mute'] = TRUE;
+      }
+    }
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('stanford_paragraph_video')->error($e->getMessage());
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allows for muted option in the video embed

# Needed By (Date)
- Soonish

# Urgency
- Client seems to care greatly

# Steps to Test

1. Use in conjunction with https://github.com/stanford-earth/SE3_BLT/pull/141

# Affected Projects or Products
- https://github.com/stanford-earth/SE3_BLT/pull/141

# Associated Issues and/or People
- EARTH-990

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)